### PR TITLE
dkms: use all CPU threads

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,7 +1,7 @@
 PACKAGE_NAME="rtl8821cu"
 PACKAGE_VERSION="5.8.1.7"
 BUILT_MODULE_NAME[0]="8821cu"
-MAKE="'make' all KVER=${kernelver} -j3"
+MAKE="'make' all KVER=${kernelver} -j$(nproc)"
 CLEAN="'make' clean"
 DEST_MODULE_LOCATION[0]="/updates/dkms"
 AUTOINSTALL="YES"


### PR DESCRIPTION
nproc returns the # of available processor threads, for a system like mine (12 threads), 3 simply isn't enough. This works nicely with the -j option.
Note: nproc is bundled with the GNU Core Utils so it should work on basically all Linux systems.