### PR TITLE
88xx backports

### DIFF
--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -3882,7 +3882,7 @@ static sint fill_radiotap_hdr(_adapter *padapter, union recv_frame *precvframe, 
 
 	u8 data_rate[] = {
 		2, 4, 11, 22, /* CCK */
-		12, 18, 24, 36, 48, 72, 93, 108, /* OFDM */
+		12, 18, 24, 36, 48, 72, 96, 108, /* OFDM */
 		0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, /* HT MCS index */
 		16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
 		0, 1, 2, 3, 4, 5, 6, 7, 8, 9, /* VHT Nss 1 */

--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -3965,11 +3965,20 @@ static sint fill_radiotap_hdr(_adapter *padapter, union recv_frame *precvframe, 
 	rt_len += 2;
 
 	/* channel flags */
-	tmp_16bit = 0;
-	if (pHalData->current_band_type == BAND_ON_2_4G)
-		tmp_16bit |= cpu_to_le16(IEEE80211_CHAN_2GHZ);
-	else /*BAND_ON_5G*/
-		tmp_16bit |= cpu_to_le16(IEEE80211_CHAN_5GHZ);
+	// NOTE: tmp_16bit currently contains channel freq; we overwrite the value
+	// to reflect channel flags.
+	if (pHalData->current_band_type == BAND_ON_2_4G){
+		tmp_16bit = cpu_to_le16(IEEE80211_CHAN_2GHZ);
+	}
+	else if (pHalData->current_band_type == BAND_ON_5G)
+		tmp_16bit = cpu_to_le16(IEEE80211_CHAN_5GHZ);
+	else { // BAND_ON_BOTH; decide based on frequency
+		if (tmp_16bit >= 5000) {
+			tmp_16bit = cpu_to_le16(IEEE80211_CHAN_5GHZ);
+		} else {
+			tmp_16bit = cpu_to_le16(IEEE80211_CHAN_2GHZ);
+		}
+	}
 
 	if (pattrib->data_rate <= DESC_RATE54M) {
 		if (pattrib->data_rate <= DESC_RATE11M) {

--- a/hal/rtl8821c/usb/rtl8821cu_xmit.c
+++ b/hal/rtl8821c/usb/rtl8821cu_xmit.c
@@ -315,7 +315,7 @@ static s32 update_txdesc(struct xmit_frame *pxmitframe, u8 *pmem, s32 sz, u8 bag
 			if (pattrib->retry_ctrl == _TRUE)
 				SET_TX_DESC_RTS_DATA_RTY_LMT_8821C(ptxdesc, 6);
 			else
-				SET_TX_DESC_RTS_DATA_RTY_LMT_8821C(ptxdesc, 12);
+				SET_TX_DESC_RTS_DATA_RTY_LMT_8821C(ptxdesc, 0);
 		}
 
 #ifdef CONFIG_XMIT_ACK


### PR DESCRIPTION
Backport some fixes that were submitted to aircrack-ng rtl8812au driver:

- Correctly report 48Mbps not 46.5Mbps rate in radiotap header
- Correctly report the frequency band in radiotap header (BAND_ON_BOTH bug)
- Disabling transmit retry should not retry the packet 12 times

The first two are important when utilizing radiotap header info in monitor mode.


Fixes originally from: https://github.com/SonarWireless/rtl8812au
Fixes accepted into: https://github.com/aircrack-ng/rtl8812au