### PR TITLE
FCS bit fix

### DIFF
--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -3927,9 +3927,10 @@ static sint fill_radiotap_hdr(_adapter *padapter, union recv_frame *precvframe, 
 	if (pattrib->mfrag)
 		hdr_buf[rt_len] |= IEEE80211_RADIOTAP_F_FRAG;
 
-	/* always append FCS */
-	hdr_buf[rt_len] |= IEEE80211_RADIOTAP_F_FCS;
-
+#ifdef CONFIG_RX_PACKET_APPEND_FCS
+	if (rtw_hal_rcr_check(padapter, BIT_APP_FCS_8821C))
+		hdr_buf[rt_len] |= IEEE80211_RADIOTAP_F_FCS;
+#endif
 
 	if (0)
 		hdr_buf[rt_len] |= IEEE80211_RADIOTAP_F_DATAPAD;


### PR DESCRIPTION
Fix FCS bit in RX header-- namely, don't indicate FCS is there if it is not... which breaks Wireshark viewing and other parsing of the last 4 bytes of the packet.