### PR TITLE
Change a printk to _RTW_DBG to avoid printing garbage logs

### DIFF
--- a/hal/phydm/phydm_debug.h
+++ b/hal/phydm/phydm_debug.h
@@ -89,7 +89,7 @@
 	#define PHYDM_SNPRINTF		snprintf
 #elif (DM_ODM_SUPPORT_TYPE == ODM_CE)
 	#undef	pr_debug
-	#define pr_debug		printk
+	#define pr_debug		_RTW_DBG
 	#define RT_PRINTK(fmt, args...)	pr_debug(fmt, ## args)
 	#define	RT_DISP(dbgtype, dbgflag, printstr)
 	#define RT_TRACE(adapter, comp, drv_level, fmt, args...)	\


### PR DESCRIPTION
without this, the kernel logs would be filled with garbage like `start_addr=(0x8000), end_addr=(0x10000), buffer_size=(0x8000), smp_number_max=(4096)`